### PR TITLE
added order details

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@
 // App
 @import "products";
 @import "categories";
+@import "orders";
 
 // Global
 body {

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -1,0 +1,52 @@
+ main section.categories-show {
+   .categories {
+     display: flex;
+     flex-direction: row;
+     flex-wrap: wrap;
+     justify-content: space-around;
+     .category {
+       // flex:      1;
+       max-width: 260px;
+       // so that footer within can be positioned absolutely
+       position: relative;
+       border: 1px solid #ccc;
+       border-radius: 5px;
+       padding: 15px;
+       padding-bottom: 80px;
+       margin-top: 20px;
+       // margin:        10px;
+       header img {
+         max-width: 100%;
+         max-height: 140px;
+         margin: auto;
+         display: block;
+       }
+       footer {
+         position: absolute;
+         bottom: 0;
+         left: 0;
+         background-color: #EEE;
+         padding: 15px;
+         border-bottom-left-radius: 5px;
+         border-bottom-right-radius: 5px;
+         width: 100%;
+         opacity: 0.3;
+         transition: all 0.3s;
+       }
+       &:hover {
+         border-color: #999;
+         footer {
+           opacity: 1.0;
+         }
+       }
+     }
+   }
+ }
+ 
+ main section.categories-show {
+   .category-detail {
+     img.main-img {
+       max-width: 100%;
+     }
+   }
+ }

--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -1,0 +1,56 @@
+main section.orders-index,
+main section.orders.show {
+
+  .orders {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-around;
+
+    .order {
+      max-width: 260px;
+      position: relative;
+      border: 1px solid #ccc;
+      border-radius: 5px;
+      padding: 15px;
+      padding-bottom: 80px;
+      margin-top: 20px;
+
+      header img {
+        max-width: 100%;
+        max-height: 140px;
+        margin: auto;
+        display: block;
+      }
+
+      footer {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        background-color: #EEE;
+        padding: 15px;
+        border-bottom-left-radius: 5px;
+        border-bottom-right-radius: 5px;
+        width: 100%;
+        opacity: 0.3;
+        transition: all 0.3s;
+      }
+
+      &:hover {
+        border-color: #999;
+
+        footer {
+          opacity: 1.0;
+        }
+      }
+    }
+  }
+}
+
+main section.orders-show {
+  .product-detail {
+    img.main-img {
+      max-width: 100%;
+    }
+  }
+}

--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -1,5 +1,5 @@
 main section.products-index,
-main section.categories-show {
+main section.products-show {
 
   .products {
     display:         flex;
@@ -8,9 +8,7 @@ main section.categories-show {
     justify-content: space-around;
 
     .product {
-      // flex:      1;
       max-width: 260px;
-      // so that footer within can be positioned absolutely
       position:  relative;
 
       border:        1px solid #ccc;
@@ -18,7 +16,6 @@ main section.categories-show {
       padding:       15px;
       padding-bottom: 80px;
       margin-top:    20px;
-      // margin:        10px;
 
       header img {
         max-width: 100%;

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,6 +4,7 @@ class OrdersController < ApplicationController
 
   def show
     @order = Order.find(params[:id])
+    @line_items = LineItem.where('order_id = ?', params[:id])
   end
 
   def create

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,6 +2,7 @@ class Order < ActiveRecord::Base
 
   belongs_to :user
   has_many :line_items
+  has_many :products, through: :line_items
 
   monetize :total_cents, numericality: true
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,6 +4,8 @@ class Product < ActiveRecord::Base
   mount_uploader :image, ProductImageUploader
 
   belongs_to :category
+  has_many :line_items
+  has_many :orders, though: :line_items
 
   validates :name, presence: true
   validates :price, presence: true

--- a/app/views/orders/_order.html.erb
+++ b/app/views/orders/_order.html.erb
@@ -1,0 +1,23 @@
+<% if product = Product.find_by(:id product_id) %>
+  <% item_total = product.price * quantity %>
+  <% @order_total += item_total %>
+  <tr>
+    <td>
+    <%= image_tag product.image.tiny %>
+    </td>
+    <td>
+      <h4><%= product.name %></h4>
+      <br>
+      <p><%= product.description %></p>
+    </td>
+    <td>
+      <%= product.price %>
+    </td>
+    <td>
+      <%= quantity %>
+    </td>
+    <td>
+      <%= item_total %>
+    </td>
+  </tr>
+  <% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -4,6 +4,35 @@
     <h1>Order #<%= @order.id %></h1>
   </header>
 
+<div class="panel panel:default items">
+  <table class="table table-bordered">
+    <thread>
+      <tr>
+        <th colspan="2">Product</th>
+        <th>Unit Price</th>
+        <th>Quantity</th>
+        <th>Price</th>
+      </tr>
+    </thread>
+    <tbody>
+      <% @order_total = 0 %>
+      <% @line_items.each do |line| %>
+      <%= render 'order', product_id: line_item[:product_id], quantity: line_item[:quantity] %>
+      <% end %>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th colspan="4">
+        TOTAL:
+        </th>
+        <th>
+          <%= order_total %>
+        </th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+
   <div class="order-summary jumbotron">
     <h4>Thank you for your order!</h4>
   </div>


### PR DESCRIPTION
Once the user places their order successfully, it doesn't give them enough detail about what they just ordered.

Change the Order show page to contain:

The items in the order and:
Their image, name and description
Their respective quantities and line item totals
The final amount for the order
The email that was used