### PR TITLE
logged out user product view not able to see fixed

### DIFF
--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -38,7 +38,7 @@
       <p> Rating: <%= review.rating %>/5</p>
       <p> Reviewed by <%= User.find(review.user_id).first_name %><%= User.find(review.user_id).last_name %></p>
       <p><%= review.description %></p>
-      <% if current_user.id == review.user_id %>
+      <% if current_user && current_user.id == review.user_id %>
       <p>
       <%= link_to fa_icon('trash'),
       [review.product, review],


### PR DESCRIPTION
When the cart is empty and the user goes to the carts#show page, instead of displaying the contents and a stripe checkout button, display a friendly message about how it is empty and link to the home page.